### PR TITLE
Support for multiple digits

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -2,5 +2,5 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
-usr/lib/*/ruby/*/msgs[0-99]/*
-usr/share/gz/*-msgs*/*-msgs[0-9].tag.xml
+usr/lib/*/ruby/*/msgs[0-99]*/*
+usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml


### PR DESCRIPTION
Nightlies are failing due to lack of support for multiple digits in the version. This PR solves it.

Tested [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-msgs10-debbuilder&build=6)](https://build.osrfoundation.org/job/gz-msgs10-debbuilder/6/)