### PR TITLE
Change installation for message generation

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -2,5 +2,6 @@ usr/bin/*
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
+usr/lib/cmake/*-msgs*/*
 usr/lib/*/cmake/*-msgs*/*
 usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml

--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -2,6 +2,5 @@ usr/bin/*
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
-usr/lib/cmake/*-msgs*/*
 usr/lib/*/cmake/*-msgs*/*
 usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml

--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -1,6 +1,6 @@
+usr/bin/*
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
-usr/lib/*/ruby/*/msgs[0-99]/*
 usr/share/gz/*-msgs*/*-msgs[0-9].tag.xml

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -1,4 +1,5 @@
 usr/lib/*/*.so.*
+usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
 usr/share/protos/*

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -1,4 +1,4 @@
 usr/lib/*/*.so.*
-usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
+usr/share/protos/*


### PR DESCRIPTION
Install the generation scripts and compiler in the dev package.

Install the protos in the main package.

No longer installing ruby.

Should fix debbuilder failures such as https://build.osrfoundation.org/view/ign-harmonic/job/gz-msgs10-debbuilder/298/console