### PR TITLE
Revert "Change installation for message generation"

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -1,6 +1,6 @@
-usr/bin/*
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
+usr/lib/*/ruby/*/msgs[0-99]*/*
 usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -2,4 +2,3 @@ usr/lib/*/*.so.*
 usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
-usr/share/protos/*


### PR DESCRIPTION
There are some other blockers in the message generation work.  For now, revert the release so that downstream libraries are not impacted.

Reverts gazebo-release/gz-msgs10-release#3