### PR TITLE
Install python files, remove ruby files

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -2,5 +2,5 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
-usr/lib/*/ruby/*/msgs[0-99]*/*
+usr/lib/*/python/*
 usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml


### PR DESCRIPTION
https://github.com/gazebosim/gz-msgs/pull/362 removed ruby file generation and added python generation. This updates the install rules to reflect that.