### PR TITLE
Add new files

### DIFF
--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -1,3 +1,4 @@
+usr/bin/*
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc

--- a/ubuntu/debian/libgz-msgs-dev.install
+++ b/ubuntu/debian/libgz-msgs-dev.install
@@ -4,3 +4,4 @@ usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/*-msgs*/*
 usr/share/gz/*-msgs*/*-msgs[0-9]*.tag.xml
+usr/share/gz/gz-msgs*/protos/*

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -3,3 +3,4 @@ usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
 usr/share/gz/gz-msgs*/protos/*
+usr/share/gz/protos/*

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -2,3 +2,4 @@ usr/lib/*/*.so.*
 usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
+usr/share/gz/gz-msgs*/protos/*

--- a/ubuntu/debian/libgz-msgs.install
+++ b/ubuntu/debian/libgz-msgs.install
@@ -2,5 +2,4 @@ usr/lib/*/*.so.*
 usr/lib/ruby/gz/*.rb
 usr/share/gz/*.yaml
 usr/share/gz/*.completion*/*
-usr/share/gz/gz-msgs*/protos/*
 usr/share/gz/protos/*


### PR DESCRIPTION
https://build.osrfoundation.org/job/gz-msgs10-debbuilder/446 shows a few files are not included in the deb package.

```
dh_missing: warning: usr/bin/gz-msgs10_generate.py exists in debian/tmp but is not installed to anywhere 
dh_missing: warning: usr/bin/gz-msgs10_generate_factory.py exists in debian/tmp but is not installed to anywhere 
dh_missing: warning: usr/bin/gz-msgs10_protoc_plugin exists in debian/tmp but is not installed to anywhere 
dh_missing: warning: usr/share/gz/gz-msgs10/protos/gz/msgs/actor.proto exists in debian/tmp but is not installed to anywhere # for all .proto files
dh_missing: warning: usr/share/gz/protos/gz-msgs10.gz_desc exists in debian/tmp but is not installed to anywhere 
```

Questions:
* Should `.proto` files be in `libgz-msgs` or `libgz-msgs-dev`?
* Is `usr/share/gz/protos/gz-msgs10.gz_desc` correct? Should it be installed to the same location as the `.proto` files?